### PR TITLE
Create GitHub Webhook for BDD Testing with Tekton (In Progress)

### DIFF
--- a/tekton/pipeline/promotion-pipeline.yaml
+++ b/tekton/pipeline/promotion-pipeline.yaml
@@ -1,0 +1,74 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: promotion-pipeline
+spec:
+  workspaces:
+    - name: source
+  params:
+    - name: repo-url
+      description: The git repository URL
+    - name: branch-name
+      description: The git branch
+      default: "main"
+    - name: service-name
+      description: The name of the service to deploy
+      default: "promotion"
+    - name: app-namespace
+      description: The namespace where the app is deployed
+      default: "default"
+  tasks:
+    - name: git-clone
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: source
+      params:
+        - name: url
+          value: $(params.repo-url)
+        - name: revision
+          value: $(params.branch-name)
+    
+    - name: build-image
+      taskRef:
+        name: kaniko
+      runAfter:
+        - git-clone
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: IMAGE
+          value: "cluster-registry:5000/$(params.service-name):latest"
+        - name: CONTEXT
+          value: "."
+    
+    - name: deploy-to-k8s
+      taskRef:
+        name: kubernetes-actions
+      runAfter:
+        - build-image
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: script
+          value: |
+            kubectl apply -f k8s/postgres
+            kubectl apply -f k8s/deployment.yaml
+            kubectl apply -f k8s/service.yaml
+            kubectl apply -f k8s/ingress.yaml
+            kubectl rollout status deployment/$(params.service-name) -n $(params.app-namespace) --timeout=180s
+
+    - name: behave-tests
+      taskRef:
+        name: behave-tests
+      runAfter:
+        - deploy-to-k8s
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: base-url
+          value: "http://$(params.service-name).$(params.app-namespace).svc.cluster.local:8080"

--- a/tekton/tasks/behave-tests.yaml
+++ b/tekton/tasks/behave-tests.yaml
@@ -1,0 +1,43 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: behave-tests
+spec:
+  description: |
+    This task runs Behave BDD tests against the deployed service.
+  params:
+    - name: base-url
+      description: The base URL of the deployed service
+      default: "http://promotion:8080"
+    - name: wait-seconds
+      description: Maximum wait time for UI operations
+      default: "60"
+  steps:
+    - name: run-behave-tests
+      image: rofrano/nyu-devops-base:sp25
+      env:
+        - name: BASE_URL
+          value: $(params.base-url)
+        - name: WAIT_SECONDS
+          value: $(params.wait-seconds)
+      workingDir: /workspace/source
+      script: |
+        #!/bin/bash
+        set -e
+        
+        echo "Installing Chrome and ChromeDriver..."
+        apt-get update
+        apt-get install -y wget unzip google-chrome-stable
+        
+        CHROME_DRIVER_VERSION=$(google-chrome --version | awk '{print $3}' | cut -d. -f1)
+        wget -q "https://edgedl.me.gserviceusercontent.com/edgedl/chrome/chrome-for-testing/120.0.6099.71/linux64/chromedriver-linux64.zip" -O /tmp/chromedriver.zip
+        unzip /tmp/chromedriver.zip -d /tmp/
+        mv /tmp/chromedriver-linux64/chromedriver /usr/bin/chromedriver
+        chmod +x /usr/bin/chromedriver
+        
+        echo "Setting up Python environment..."
+        python -m pip install --upgrade pip
+        pipenv install --system --dev
+        
+        echo "Running Behave tests against $BASE_URL..."
+        pipenv run behave

--- a/tekton/triggers/trigger-binding.yaml
+++ b/tekton/triggers/trigger-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerBinding
+metadata:
+  name: github-push-binding
+spec:
+  params:
+    - name: gitRepository
+      value: $(body.repository.url)
+    - name: gitRevision
+      value: $(body.ref)
+    - name: contentType
+      value: $(header.Content-Type)


### PR DESCRIPTION
This PR begins the implementation of a GitHub webhook integration with Tekton to run Behave BDD tests against our deployed service. So far, I've added:

A Tekton task for running Behave tests with Selenium
CI/CD pipeline configuration
GitHub trigger binding setup

Closes #72

Still to be completed:

Trigger template configuration
Event listener setup
Service account and RBAC configuration
Webhook secret template
Setup documentation

This initial submission establishes the directory structure and core components. I'll continue adding the remaining files to complete the webhook implementation that will allow our BDD tests to run automatically on every push to the main branch.